### PR TITLE
docs(ui): add navigation + forms guidelines; update Config entry

### DIFF
--- a/apps/docs/docs/frontend/ui.md
+++ b/apps/docs/docs/frontend/ui.md
@@ -4,6 +4,12 @@ title: UI & Components
 
 SwiftUI views are small, composable, and previewable. Emphasize accessibility and performance.
 
+UI Navigation Patterns
+- Tab navigation: Primary app sections are exposed via the bottom tab bar (Today, Habits, Settings, etc.). Screens should not hide the tab bar unless in a modal flow.
+- Pill navigation: Within a screen (e.g., Habits), use horizontal “chips” (peels) to switch between local sections (Player / Habits / Areas / Store). The selected pill is filled (blue), others are neutral. A Config pill appears at the end to open the User Config sheet.
+- Spotify‑like actions: Use swipe actions on list rows. Leading full swipe auto‑executes the primary action (Record). Trailing full swipe opens Edit; Delete is trailing and always asks for confirmation.
+- Forms: Use native SwiftUI Forms. For Habits, Area is chosen via a Picker populated from the Areas catalog. Bad Habits allow “None (Global)”. Avoid manual ID entry.
+
 Habits Header (Global XP)
 ```swift
 VStack(alignment: .leading) {
@@ -27,14 +33,10 @@ VStack(alignment: .leading) {
 }
 ```
 
-Config Entry (gear icon)
+Config Entry (pill in chip bar)
 ```swift
-.toolbar {
-  ToolbarItem(placement: .navigationBarTrailing) {
-    Button { showingConfig = true } label: { Image(systemName: "gearshape") }
-  }
-}
-.sheet(isPresented: $showingConfig) { UserConfigSheet(onSaved: { Task { await profileVM.refresh() } }) }
+TileNav(selected: $selected, onConfig: { showingConfig = true })
+  .sheet(isPresented: $showingConfig) { UserConfigSheet(onSaved: { Task { await profileVM.refresh() } }) }
 ```
 
 Example List

--- a/apps/mobileIOS/README.md
+++ b/apps/mobileIOS/README.md
@@ -14,7 +14,7 @@ Native iOS client for Habit Hero, built with Swift 5.9+, SwiftUI, MVVM, async/aw
 - Habits CRUD, quick completion (awards XP/coins)
 - Global profile stats: life, coins, and global Level/XP derived from your activity
 - Clear progress: Habits header shows “XP to next → {current} from {required}” with correct per‑level requirement (linear or exponential)
-- User Config sheet (gear icon in Habits): edit XP per Level, Level curve (linear/exp), exponential multiplier, and XP computation mode (logs vs stored)
+- User Config sheet (Config pill in Habits chip bar): edit XP per Level, Level curve (linear/exp), exponential multiplier, and XP computation mode (logs vs stored)
 - Settings: editable API base URL
 
 ## Getting Started
@@ -55,6 +55,13 @@ The app targets the backend routes documented in the API docs and OpenAPI (Swagg
 - Store endpoints as applicable
 
 Ensure the backend is running and seeded so the app has demo data.
+
+## UI Patterns
+
+- Tab navigation: primary screens via bottom tabs.
+- Pill navigation: horizontal chip bar for local sections (Player / Habits / Areas / Store) and a Config pill.
+- Spotify‑like actions: leading full swipe = Record; trailing full swipe = Edit (full), Delete (with confirm).
+- Forms: Good/Bad create & edit forms use Area pickers sourced from the Areas catalog. Bad can be “None (Global)”.
 
 ## Testing
 


### PR DESCRIPTION
What & Why
- Add a concise UI guide to standardize navigation and forms across screens.
- Update references to Config entry (now a pill in the chip bar, not header gear).

Changes
- apps/docs/docs/frontend/ui.md: added UI Navigation Patterns (Tab, Pill, Spotify-like swipes, Forms with Area pickers) and updated Config example.
- apps/mobileIOS/README.md: added UI Patterns section; updated Config reference.

How to QA
- Open the docs site: Frontend → UI & Components. Verify new patterns are documented and rendered.
- Open apps/mobileIOS/README.md; check the new UI Patterns section.

Rollback
- Revert this commit if the documentation needs to be split or moved to a separate page.
