### PR TITLE
feat(api): soft delete + restore + unified archive

### DIFF
--- a/apps/api/prisma/migrations/20250908_soft_delete/migration.sql
+++ b/apps/api/prisma/migrations/20250908_soft_delete/migration.sql
@@ -1,0 +1,10 @@
+-- Add deletedAt columns and indexes for soft delete
+ALTER TABLE "Area" ADD COLUMN "deletedAt" DATETIME;
+CREATE INDEX IF NOT EXISTS "Area_deletedAt_idx" ON "Area" ("deletedAt");
+
+ALTER TABLE "GoodHabit" ADD COLUMN "deletedAt" DATETIME;
+CREATE INDEX IF NOT EXISTS "GoodHabit_deletedAt_idx" ON "GoodHabit" ("deletedAt");
+
+ALTER TABLE "BadHabit" ADD COLUMN "deletedAt" DATETIME;
+CREATE INDEX IF NOT EXISTS "BadHabit_deletedAt_idx" ON "BadHabit" ("deletedAt");
+

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -41,6 +41,9 @@ model Area {
   habits      GoodHabit[]
   badHabits   BadHabit[]
   areaLevels  AreaLevel[]
+  deletedAt   DateTime?
+
+  @@index([deletedAt])
 }
 
 model GoodHabit {
@@ -53,6 +56,9 @@ model GoodHabit {
   cadence    String?
   logs       HabitLog[]
   isActive   Boolean    @default(true)
+  deletedAt  DateTime?
+
+  @@index([deletedAt])
 }
 
 model BadHabit {
@@ -66,6 +72,9 @@ model BadHabit {
   logs          BadHabitLog[]
   isActive      Boolean      @default(true)
   ownedBy       UserOwnedBadHabit[]
+  deletedAt     DateTime?
+
+  @@index([deletedAt])
 }
 
 model AreaLevel {

--- a/apps/api/src/router/actions.ts
+++ b/apps/api/src/router/actions.ts
@@ -6,8 +6,8 @@ const DEFAULT_USER_ID = "seed-user-1";
 const router = Router();
 
 router.post("/habits/:id/complete", async (req, res) => {
-  const habit = await prisma.goodHabit.findUnique({ where: { id: req.params.id }, include: { area: true } });
-  if (!habit || !habit.area) return res.status(404).json({ message: "Habit not found" });
+  const habit = await prisma.goodHabit.findFirst({ where: { id: req.params.id, deletedAt: null }, include: { area: true } });
+  if (!habit || !habit.area || (habit.area as any).deletedAt) return res.status(404).json({ message: "Habit not found" });
 
   // get or create AreaLevel
   let areaLevel = await prisma.areaLevel.findUnique({ where: { userId_areaId: { userId: DEFAULT_USER_ID, areaId: habit.areaId } } });
@@ -49,7 +49,7 @@ router.post("/habits/:id/complete", async (req, res) => {
 });
 
 router.post("/bad-habits/:id/record", async (req, res) => {
-  const bad = await prisma.badHabit.findUnique({ where: { id: req.params.id } });
+  const bad = await prisma.badHabit.findFirst({ where: { id: req.params.id, deletedAt: null } });
   if (!bad) return res.status(404).json({ message: "Bad habit not found" });
 
   let avoidedPenalty = false;

--- a/apps/api/src/router/archive.ts
+++ b/apps/api/src/router/archive.ts
@@ -1,0 +1,18 @@
+import { Router } from "express";
+import prisma from "../lib/prisma";
+
+const DEFAULT_USER_ID = "seed-user-1";
+const router = Router();
+
+// Unified archive listing: areas, habits, bad habits
+router.get("/", async (_req, res) => {
+  const [areas, habits, badHabits] = await Promise.all([
+    prisma.area.findMany({ where: { userId: DEFAULT_USER_ID, deletedAt: { not: null } } }),
+    prisma.goodHabit.findMany({ where: { deletedAt: { not: null } }, include: { area: true } }),
+    prisma.badHabit.findMany({ where: { deletedAt: { not: null } }, include: { area: true } }),
+  ]);
+  res.json({ areas, habits, badHabits });
+});
+
+export default router;
+

--- a/apps/api/src/router/index.ts
+++ b/apps/api/src/router/index.ts
@@ -6,6 +6,7 @@ import actions from "./actions";
 import store from "./store";
 import me from "./me";
 import users from "./users";
+import archive from "./archive";
 
 const api = Router();
 api.get("/__ping", (_req, res) => res.json({ ok: true }));
@@ -16,5 +17,6 @@ api.use("/actions", actions);
 api.use("/store", store);
 api.use("/me", me);
 api.use("/users", users);
+api.use("/archive", archive);
 
 export default api;

--- a/apps/api/src/router/me.ts
+++ b/apps/api/src/router/me.ts
@@ -10,9 +10,9 @@ router.get("/", async (_req, res) => {
   if (!user) return res.status(404).json({ message: "User not found" });
 
   const [areas, levels, owned] = await Promise.all([
-    prisma.area.findMany({ where: { userId: DEFAULT_USER_ID } }),
+    prisma.area.findMany({ where: { userId: DEFAULT_USER_ID, deletedAt: null } }),
     prisma.areaLevel.findMany({ where: { userId: DEFAULT_USER_ID } }),
-    prisma.userOwnedBadHabit.findMany({ where: { userId: DEFAULT_USER_ID }, include: { badHabit: true } }),
+    prisma.userOwnedBadHabit.findMany({ where: { userId: DEFAULT_USER_ID, badHabit: { deletedAt: null } }, include: { badHabit: true } }),
   ]);
 
   const byArea = new Map(levels.map((l) => [l.areaId, l]));

--- a/apps/api/src/router/store.ts
+++ b/apps/api/src/router/store.ts
@@ -6,7 +6,7 @@ const router = Router();
 
 // Purchase a controlled bad habit so future records avoid life penalty
 router.post("/bad-habits/:id/buy", async (req, res) => {
-  const bad = await prisma.badHabit.findUnique({ where: { id: req.params.id } });
+  const bad = await prisma.badHabit.findFirst({ where: { id: req.params.id, deletedAt: null } });
   if (!bad) return res.status(404).json({ message: "Bad habit not found" });
   // All bad habits are purchasable; controllable flag is ignored
 


### PR DESCRIPTION
Adds soft delete (deletedAt) for Area/GoodHabit/BadHabit with indexes.

- Default GETs exclude archived; unified GET /archive lists archived items by type
- Restore endpoints: POST /areas/:id/restore, /habits/:id/restore, /bad-habits/:id/restore
- Guards actions/store/me against archived; validate active area on create/update

Migration
- pnpm db:migrate && pnpm -F @habit-hero/api prisma generate

Test plan
- pnpm db:seed
- pnpm -F @habit-hero/api test:soft-delete (prints JSON summary; all steps should pass)
