### PR TITLE
feat(iOS): token-aligned Design System components

### DIFF
--- a/apps/mobileIOS/mobileIOS/DesignSystem/DesignSystem.swift
+++ b/apps/mobileIOS/mobileIOS/DesignSystem/DesignSystem.swift
@@ -85,7 +85,38 @@ struct CardModifier: ViewModifier {
     }
 }
 
+struct PrimaryButtonStyle: ButtonStyle {
+    @Environment(\.colorScheme) private var scheme
+    func makeBody(configuration: Configuration) -> some View {
+        let c = DSTheme.colors(for: scheme)
+        return configuration.label
+            .foregroundStyle(c.textPrimary)
+            .padding(.horizontal, 24)
+            .padding(.vertical, 10)
+            .background(RoundedRectangle(cornerRadius: 24).fill(c.accentPrimary))
+            .overlay(
+                RoundedRectangle(cornerRadius: 24)
+                    .fill(Color.white.opacity(configuration.isPressed ? 0.14 : 0))
+            )
+            .shadow(color: c.accentPrimary.opacity(0.25), radius: 8)
+            .scaleEffect(configuration.isPressed ? 0.98 : 1)
+    }
+}
+
+struct SecondaryButtonStyle: ButtonStyle {
+    @Environment(\.colorScheme) private var scheme
+    func makeBody(configuration: Configuration) -> some View {
+        let c = DSTheme.colors(for: scheme)
+        return configuration.label
+            .foregroundStyle(c.accentPrimary)
+            .padding(.horizontal, 24)
+            .padding(.vertical, 10)
+            .background(RoundedRectangle(cornerRadius: 16).fill(c.surfaceCard))
+            .overlay(RoundedRectangle(cornerRadius: 16).stroke(c.accentPrimary, lineWidth: 1))
+            .scaleEffect(configuration.isPressed ? 0.98 : 1)
+    }
+}
+
 extension View {
     func cardStyle() -> some View { modifier(CardModifier()) }
 }
-

--- a/apps/mobileIOS/mobileIOS/Views/AreasView.swift
+++ b/apps/mobileIOS/mobileIOS/Views/AreasView.swift
@@ -76,7 +76,7 @@ struct NewAreaSheet: View {
             .navigationTitle("New Area")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
-                ToolbarItem(placement: .confirmationAction) { Button("Create") { onCreate(name, icon.isEmpty ? nil : icon, xpPerLevel, levelCurve, levelCurve == "exp" ? levelMultiplier : nil); dismiss() }.disabled(name.isEmpty) }
+                ToolbarItem(placement: .confirmationAction) { Button("Create") { onCreate(name, icon.isEmpty ? nil : icon, xpPerLevel, levelCurve, levelCurve == "exp" ? levelMultiplier : nil); dismiss() }.buttonStyle(PrimaryButtonStyle()).disabled(name.isEmpty) }
             }
         }
         .presentationDetents([.medium, .large])

--- a/apps/mobileIOS/mobileIOS/Views/Edit/AreaEditSheet.swift
+++ b/apps/mobileIOS/mobileIOS/Views/Edit/AreaEditSheet.swift
@@ -43,7 +43,7 @@ struct AreaEditSheet: View {
             .navigationTitle("Edit Area")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
-                ToolbarItem(placement: .confirmationAction) { Button("Save") { onSave(area); dismiss() }.keyboardShortcut(.defaultAction) }
+                ToolbarItem(placement: .confirmationAction) { Button("Save") { onSave(area); dismiss() }.buttonStyle(PrimaryButtonStyle()).keyboardShortcut(.defaultAction) }
             }
         }
     }

--- a/apps/mobileIOS/mobileIOS/Views/Edit/BadHabitEditSheet.swift
+++ b/apps/mobileIOS/mobileIOS/Views/Edit/BadHabitEditSheet.swift
@@ -50,7 +50,7 @@ struct BadHabitEditSheet: View {
                                                coinCost: item.coinCost,
                                                isActive: item.isActive)
                         onSave(updated); dismiss()
-                    }.keyboardShortcut(.defaultAction)
+                    }.buttonStyle(PrimaryButtonStyle()).keyboardShortcut(.defaultAction)
                 }
             }
         }

--- a/apps/mobileIOS/mobileIOS/Views/Edit/HabitEditSheet.swift
+++ b/apps/mobileIOS/mobileIOS/Views/Edit/HabitEditSheet.swift
@@ -43,7 +43,7 @@ struct HabitEditSheet: View {
                     Button("Save") {
                         let updated = GoodHabit(id: habit.id, areaId: selectedAreaId, name: habit.name, xpReward: habit.xpReward, coinReward: habit.coinReward, cadence: habit.cadence, isActive: habit.isActive)
                         onSave(updated); dismiss()
-                    }.keyboardShortcut(.defaultAction)
+                    }.buttonStyle(PrimaryButtonStyle()).keyboardShortcut(.defaultAction)
                 }
             }
         }

--- a/apps/mobileIOS/mobileIOS/Views/HabitsView.swift
+++ b/apps/mobileIOS/mobileIOS/Views/HabitsView.swift
@@ -287,7 +287,7 @@ private struct CombinedHabitsPanel: View {
                     VStack(alignment: .leading, spacing: 6) {
                         HStack { Text(habit.name).font(.headline); Spacer(); Text("XP +\(habit.xpReward) • Coins +\(habit.coinReward)").font(.caption).foregroundStyle(.secondary) }
                         Button("Record") { Task { _ = await goodVM.complete(id: habit.id) } }
-                            .buttonStyle(.borderedProminent)
+                            .buttonStyle(PrimaryButtonStyle())
                     }
                     .contentShape(Rectangle())
                     .swipeActions(edge: .leading, allowsFullSwipe: true) {
@@ -304,8 +304,7 @@ private struct CombinedHabitsPanel: View {
                     VStack(alignment: .leading, spacing: 6) {
                         HStack { Text(item.name).font(.headline); Spacer(); Text("Penalty \(item.lifePenalty)").font(.caption).foregroundStyle(.secondary) }
                         Button("Record Slip") { Task { await badVM.record(id: item.id) } }
-                            .buttonStyle(.bordered)
-                            .tint(.red)
+                            .buttonStyle(SecondaryButtonStyle())
                     }
                     .contentShape(Rectangle())
                     .swipeActions(edge: .leading, allowsFullSwipe: true) {
@@ -621,7 +620,7 @@ struct NewHabitSheet: View {
             .navigationTitle("New Habit")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
-                ToolbarItem(placement: .confirmationAction) { Button("Create") { onCreate(selectedAreaId, name, xp, coins, cadence.isEmpty ? nil : cadence, active); dismiss() }.disabled(name.isEmpty || selectedAreaId.isEmpty) }
+                ToolbarItem(placement: .confirmationAction) { Button("Create") { onCreate(selectedAreaId, name, xp, coins, cadence.isEmpty ? nil : cadence, active); dismiss() }.buttonStyle(PrimaryButtonStyle()).disabled(name.isEmpty || selectedAreaId.isEmpty) }
             }
         }
         .presentationDetents([.medium, .large])
@@ -661,7 +660,7 @@ struct HabitDetailView: View {
                 Button("Save") {
                     let updated = GoodHabit(id: habit.id, areaId: areaIdInput, name: habit.name, xpReward: habit.xpReward, coinReward: habit.coinReward, cadence: habit.cadence, isActive: habit.isActive)
                     onSave(updated); dismiss()
-                }.buttonStyle(.borderedProminent)
+                }.buttonStyle(PrimaryButtonStyle())
                 Button("Delete", role: .destructive) { onDelete(); dismiss() }
             }
         }
@@ -703,7 +702,7 @@ struct NewBadHabitSheet: View {
             .navigationTitle("New Bad Habit")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
-                ToolbarItem(placement: .confirmationAction) { Button("Create") { onCreate(selectedAreaId, name, lifePenalty, controllable, coinCost, active); dismiss() }.disabled(name.isEmpty) }
+                ToolbarItem(placement: .confirmationAction) { Button("Create") { onCreate(selectedAreaId, name, lifePenalty, controllable, coinCost, active); dismiss() }.buttonStyle(PrimaryButtonStyle()).disabled(name.isEmpty) }
             }
         }
         .presentationDetents([.medium, .large])
@@ -740,7 +739,7 @@ struct BadHabitDetailView: View {
                 Button("Save") {
                     let updated = BadHabit(id: item.id, areaId: areaIdInput.isEmpty ? nil : areaIdInput, name: item.name, lifePenalty: item.lifePenalty, controllable: item.controllable, coinCost: item.coinCost, isActive: item.isActive)
                     onSave(updated); dismiss()
-                }.buttonStyle(.borderedProminent)
+                }.buttonStyle(PrimaryButtonStyle())
                 Button("Delete", role: .destructive) { onDelete(); dismiss() }
             }
         }

--- a/apps/mobileIOS/mobileIOS/Views/StoreView.swift
+++ b/apps/mobileIOS/mobileIOS/Views/StoreView.swift
@@ -65,7 +65,7 @@ private struct BadHabitStoreRow: View {
             }
             Spacer()
             if ownedCount > 0 { Text("Owned: \(ownedCount)").font(.caption) }
-            Button("Buy", action: onBuy).buttonStyle(.borderedProminent)
+            Button("Buy", action: onBuy).buttonStyle(PrimaryButtonStyle())
         }
     }
 }


### PR DESCRIPTION
Adds token-aligned DS components (Primary/Secondary buttons), uses semantic colors from DSTheme (light/dark), applies styles to Record/Buy/Create/Save actions. Builds on the approved DS foundation + theme switch. Follow-ups: adopt spacing/card elevation; nav/tabbar; state/motion tokens; accessibility polish.